### PR TITLE
Arbitrary image size support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Note that if you install the python packages into a virtual env (as the script a
 
 `<install_path>/venv/bin/python PaperPiAI/src/generate_picture.py /tmp`
 
-To send to the display use `python PaperPiAI/src/display_picture.py <image_name>`. Use the `-p` flag if the display is in portrait mode.
+By default, the image will be 800x480 pixels. If you want to generate a portrait image or a different sized image, pass `--width` and `--height` appropriately.
+
+To send to the display use `python PaperPiAI/src/display_picture.py <image_name>`. Use the `-p` flag if the display is in portrait mode. Use `--width` and `--height` to specify the size of the display (in landscape view) if necessary. The defaults are 800 and 480 respectively.
 
 To automate this I make a script that runs these two commands in sequence and put an entry in crontab to call it once a day.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,7 +48,4 @@ cmake --build . --config Release
 cd "$INSTALL_DIR"
 mkdir models
 cd models
-git clone --depth=1 https://huggingface.co/AeroX2/stable-diffusion-xl-turbo-1.0-onnxstream
-
-
-
+git clone --depth=1 https://huggingface.co/vitoplantamura/stable-diffusion-xl-turbo-1.0-anyshape-onnxstream

--- a/src/display_picture.py
+++ b/src/display_picture.py
@@ -29,7 +29,7 @@ def crop(image, disp_w, disp_h, intelligent=True):
 
     if img_aspect < disp_aspect:
         # scale width, crop height.
-        resize =(disp_w, int(disp_w / img_aspect))
+        resize = (disp_w, int(disp_w / img_aspect))
     else:
         # scale height, crop width
         resize = (int(disp_h * img_aspect), disp_h)
@@ -100,24 +100,21 @@ if __name__ == "__main__":
                     default=False, help="Simply resize image to display ignoring aspect ratio")
     ap.add_argument("-s", "--simulate_display", action="store_true",
                     default=False, help="Do not interact with e-paper display")
+    ap.add_argument("--width", default=800, help="The width of the display")
+    ap.add_argument("--height", default=480, help="The height of the display")
     args = vars(ap.parse_args())
 
     simulate_display = args["simulate_display"]
 
-    if simulate_display:
-        disp_w, disp_h = (800, 480)
-    else:
+    if not simulate_display:
         inky = auto(ask_user=True, verbose=True)
-        disp_w, disp_h = inky.resolution
 
-    if args["portrait"]:
-        disp_w, disp_h = disp_h, disp_w
+    (disp_w, disp_h) = (args["height"], args["width"]) if args["portrait"] else (args["width"], args["height"])
     
     image = load_image(args["image"])
     if args["resize_only"]:
-        resize = inky.resolution
-        print(f"Resizing to {resize}")
-        image = cv2.resize(image, resize)
+        print(f"Resizing to {disp_w}x{disp_h}")
+        image = cv2.resize(image, (disp_w, disp_h))
     else:
         image = crop(image, disp_w, disp_h, args["centre_crop"]==False)
 

--- a/src/generate_picture.py
+++ b/src/generate_picture.py
@@ -10,13 +10,15 @@ def usage():
 
 parser = argparse.ArgumentParser(description="Generate a new random picture.")
 parser.add_argument("output_dir", help="Directory to save the output images")
+parser.add_argument("--width", default=480, help="The width of the image to generate")
+parser.add_argument("--height", default=800, help="The height of the image to generate")
 args = parser.parse_args()
 
 # Set the paths
 installed_dir = "/home/dylski/Projects/PaperPiAI"
 installed_dir = "./"
 sd_bin = f"{installed_dir}/OnnxStream/src/build/sd"
-sd_model = f"{installed_dir}/stable_diffusion_models/stable-diffusion-xl-turbo-1.0-onnxstream"
+sd_model = f"{installed_dir}/models/stable-diffusion-xl-turbo-1.0-anyshape-onnxstream"
 
 output_dir = args.output_dir
 shared_file = 'output.png'
@@ -77,6 +79,7 @@ cmd = [
     "--seed", str(seed),
     "--output", fullpath,
     "--steps", str(steps)
+    "--res", f"{args.width}x{args.height}"
 ]
 
 # Run the command

--- a/src/generate_picture.py
+++ b/src/generate_picture.py
@@ -10,8 +10,8 @@ def usage():
 
 parser = argparse.ArgumentParser(description="Generate a new random picture.")
 parser.add_argument("output_dir", help="Directory to save the output images")
-parser.add_argument("--width", default=480, help="The width of the image to generate")
-parser.add_argument("--height", default=800, help="The height of the image to generate")
+parser.add_argument("--width", default=800, help="The width of the image to generate")
+parser.add_argument("--height", default=480, help="The height of the image to generate")
 args = parser.parse_args()
 
 # Set the paths


### PR DESCRIPTION
Updates install.sh to pull new model data, modifications to generate_image.py and display_image.py to allow the user to provide what image size they wish to use.

I must confess the changes in display_image are untested, as I do not have an Inky display to try them with, but they are from my modifications for a Waveshare display.

Closes #8 